### PR TITLE
Add udpxy_renew_period nvram key to set udpxy param "-M : periodicall…

### DIFF
--- a/trunk/user/rc/net.c
+++ b/trunk/user/rc/net.c
@@ -244,7 +244,8 @@ start_udpxy(char *wan_ifname)
 		"-m", wan_ifname,
 		"-p", nvram_safe_get("udpxy_enable_x"),
 		"-B", "65536",
-		"-c", nvram_safe_get("udpxy_clients")
+		"-c", nvram_safe_get("udpxy_clients"),
+		"-M", nvram_safe_get("udpxy_renew_period")
 		);
 }
 

--- a/trunk/user/shared/defaults.c
+++ b/trunk/user/shared/defaults.c
@@ -647,6 +647,7 @@ struct nvram_pair router_defaults[] = {
 	{ "force_mld", "0" },
 	{ "udpxy_enable_x", "0" },
 	{ "udpxy_clients", "10" },
+	{ "udpxy_renew_period", "120" },
 #if defined(APP_XUPNPD)
 	{ "xupnpd_enable_x", "0" },
 	{ "xupnpd_udpxy", "0" },


### PR DESCRIPTION
…y renew multicast subscription (skip if 0 sec) [default = 0 sec]", and set its default value to 120 to avoid IPTV broken after 4 minutes (#569)