### PR TITLE
redsocks:fixes #567 (#576)

### DIFF
--- a/trunk/user/redsocks/Makefile
+++ b/trunk/user/redsocks/Makefile
@@ -11,4 +11,5 @@ clean:
 
 romfs:
 	$(ROMFSINST) $(THISDIR)/$(SRC_NAME)/redsocks /usr/bin/redsocks
+	cp -fP $(STAGEDIR)/lib/libevent_core-2.1.so.* $(ROMFSDIR)/lib
 #	$(ROMFSINST) -p +x $(THISDIR)/redsocks.sh /usr/bin/redsocks.sh


### PR DESCRIPTION
add missing depend
libevent_core-2.1.so.6